### PR TITLE
travis: move code style check to separate job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,11 +51,27 @@ matrix:
             - llvm-toolchain-precise-3.8
           packages:
             - clang-3.8
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc
+      env: TEST="CHECKPATCH"
 
 before_install:
         - echo 1000 | sudo tee /proc/sys/vm/nr_hugepages
         - sudo mkdir -p /mnt/huge
         - sudo mount -t hugetlbfs nodev /mnt/huge
+
+        - if [  "$TEST" = "CHECKPATCH" ]; then
+            echo ${TRAVIS_COMMIT_RANGE};
+            ODP_PATCHES=`echo ${TRAVIS_COMMIT_RANGE} | sed 's/\.//'`;
+            if [ -z "${ODP_PATCHES}" ]; then env; exit 1; fi;
+            ./scripts/ci-checkpatches.sh ${ODP_PATCHES};
+            exit $?;
+          fi
 
         - sudo apt-get -qq update
         - sudo apt-get install automake autoconf libtool libssl-dev graphviz mscgen doxygen
@@ -101,21 +117,6 @@ before_install:
         - popd
 
 script:
-        - echo $TRAVIS_COMMIT_RANGE
-        - ODP_PACHES=`echo $TRAVIS_COMMIT_RANGE | sed 's/\.//'`
-#        Generate patches provided with $TRAVIS_COMMIT_RANGE.
-#        In case of force push and range is broken validate only the latest commit if it's not merge commit.
-        - git format-patch $ODP_PACHES;
-          if [ $? -ne 0 ]; then
-            git show --summary HEAD| grep -q '^Merge:';
-            if [ $? -ne 0 ]; then
-              git format-patch HEAD^;
-              perl ./scripts/checkpatch.pl *.patch;
-            fi;
-          else
-            perl ./scripts/checkpatch.pl *.patch;
-          fi
-
         - ./bootstrap
         - ./configure
 #        doxygen does not trap on warnings, check for them here.

--- a/scripts/ci-checkpatches.sh
+++ b/scripts/ci-checkpatches.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+PATCHES=$1
+echo "Run checkpatch for ${PATCHES}"
+# Generate patches provided with $1.
+# In case of force push and range is broken
+# validate only the latest commit if it's not merge commit.
+git format-patch ${PATCHES}
+if [ $? -ne 0 ]; then
+	git show --summary HEAD| grep -q '^Merge:';
+	if [ $? -ne 0 ]; then
+		git format-patch HEAD^;
+		perl ./scripts/checkpatch.pl *.patch;
+	fi;
+else
+	perl ./scripts/checkpatch.pl *.patch;
+fi


### PR DESCRIPTION
Move this check to separate job to better see which exactly
task was failed.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>